### PR TITLE
Adding static version number for Django

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Django
+Django==2.1
 gunicorn
 django-heroku


### PR DESCRIPTION
Needed because the build fails on 2.2.